### PR TITLE
Revert "audioparsers: add back segment clipping to parsers that have …

### DIFF
--- a/gst/audioparsers/gstaacparse.c
+++ b/gst/audioparsers/gstaacparse.c
@@ -1480,8 +1480,6 @@ gst_aac_parse_pre_push_frame (GstBaseParse * parse, GstBaseParseFrame * frame)
         gst_buffer_get_size (frame->out_buffer) - header_size);
   }
 
-  frame->flags |= GST_BASE_PARSE_FRAME_FLAG_CLIP;
-
   return GST_FLOW_OK;
 }
 

--- a/gst/audioparsers/gstac3parse.c
+++ b/gst/audioparsers/gstac3parse.c
@@ -808,8 +808,6 @@ gst_ac3_parse_pre_push_frame (GstBaseParse * parse, GstBaseParseFrame * frame)
     ac3parse->sent_codec_tag = TRUE;
   }
 
-  frame->flags |= GST_BASE_PARSE_FRAME_FLAG_CLIP;
-
   return GST_FLOW_OK;
 }
 

--- a/gst/audioparsers/gstamrparse.c
+++ b/gst/audioparsers/gstamrparse.c
@@ -448,7 +448,5 @@ gst_amr_parse_pre_push_frame (GstBaseParse * parse, GstBaseParseFrame * frame)
     amrparse->sent_codec_tag = TRUE;
   }
 
-  frame->flags |= GST_BASE_PARSE_FRAME_FLAG_CLIP;
-
   return GST_FLOW_OK;
 }

--- a/gst/audioparsers/gstdcaparse.c
+++ b/gst/audioparsers/gstdcaparse.c
@@ -613,7 +613,5 @@ gst_dca_parse_pre_push_frame (GstBaseParse * parse, GstBaseParseFrame * frame)
     dcaparse->sent_codec_tag = TRUE;
   }
 
-  frame->flags |= GST_BASE_PARSE_FRAME_FLAG_CLIP;
-
   return GST_FLOW_OK;
 }

--- a/gst/audioparsers/gstsbcparse.c
+++ b/gst/audioparsers/gstsbcparse.c
@@ -529,7 +529,5 @@ gst_sbc_parse_pre_push_frame (GstBaseParse * parse, GstBaseParseFrame * frame)
     sbcparse->sent_codec_tag = TRUE;
   }
 
-  frame->flags |= GST_BASE_PARSE_FRAME_FLAG_CLIP;
-
   return GST_FLOW_OK;
 }

--- a/gst/audioparsers/gstwavpackparse.c
+++ b/gst/audioparsers/gstwavpackparse.c
@@ -704,7 +704,5 @@ gst_wavpack_parse_pre_push_frame (GstBaseParse * parse,
     wavpackparse->sent_codec_tag = TRUE;
   }
 
-  frame->flags |= GST_BASE_PARSE_FRAME_FLAG_CLIP;
-
   return GST_FLOW_OK;
 }


### PR DESCRIPTION
The change 583968ae0782682d54dd28a8307edb8b8cbf5bb0 was picked as an extra change that could be useful, but may be getting in the way of the fixes to qtdemux by restricting the amount of lead in provided to the decoder. This commit reverts that change.